### PR TITLE
Refactor tests: Make app config a param to app fixture

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,6 @@
+from bemserver_api.settings import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    AUTH_ENABLED = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Global conftest"""
-
 import datetime as dt
 
 from bemserver_core.database import db
@@ -10,17 +9,14 @@ import pytest
 from pytest_postgresql import factories as ppf
 
 from bemserver_api import create_app
-from bemserver_api.settings import Config
+
+from tests.common import TestConfig
 
 
 postgresql_proc = ppf.postgresql_proc(
     postgres_options="-c shared_preload_libraries='timescaledb'"
 )
 postgresql = ppf.postgresql('postgresql_proc')
-
-
-class TestConfig(Config):
-    TESTING = True
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,10 @@ def database(postgresql):
     yield from setup_db(postgresql)
 
 
-@pytest.fixture
-def app(database):
+@pytest.fixture(params=(TestConfig, ))
+def app(request, database):
 
-    class AppConfig(TestConfig):
+    class AppConfig(request.param):
         SQLALCHEMY_DATABASE_URI = database.url
 
     application = create_app(AppConfig)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = True
 deps =
     -r tests/requirements.txt
 commands =
-    pytest -p no:logging --cov={envsitepackagesdir}/bemserver_api --cov-branch --cov-report=term-missing
+    pytest -p no:logging --cov=bemserver_api --cov-branch --cov-report=term-missing
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Tests can now override TestConfig in app fixture.