### PR TITLE
Rework pre-commit to call pip-compile locally but not in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v2.29.1
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
+    args: [--py37-plus]
 - repo: https://github.com/python/black
   rev: 21.12b0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: 4.0.1
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear>=21.4.3]
+    additional_dependencies: [flake8-bugbear>=21.11.29]
 - repo: https://github.com/jazzband/pip-tools
   rev: 6.4.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,18 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==21.12b0]
+- repo: https://github.com/jazzband/pip-tools
+  rev: 6.4.0
+  hooks:
+    - id: pip-compile
+      name: pip-compile setup.py
+      args: [setup.py, --output-file=requirements/install.txt]
+      files: ^(setup\.py|requirements\/install\.txt)$
+    - id: pip-compile
+      name: pip-compile requirements/dev.in
+      args: [requirements/dev.in]
+      files: ^requirements\/(tests|dev)\.(in|txt)$
+    - id: pip-compile
+      name: pip-compile requirements/tests.in
+      args: [requirements/tests.in]
+      files: ^requirements\/tests\.(in|txt)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear>=21.4.3]
-- repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.0
-  hooks:
-  - id: blacken-docs
-    additional_dependencies: [black==21.12b0]
 - repo: https://github.com/jazzband/pip-tools
   rev: 6.4.0
   hooks:

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,3 @@
-# When modifying this file, run
-# pip-compile requirements/dev.in
 -r tests.in
 pip-tools
 pre-commit

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,6 +1,3 @@
-# When modifying this file, run
-# pip-compile requirements/tests.in
-# pip-compile requirements/dev.in
 pytest
 pytest-postgresql<4
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     python_requires=">=3.7",
-    # When modifying this list, run
-    # pip-compile setup.py --output-file=requirements/install.txt
     install_requires=[
         "flask>=2.0.0",
         "python-dotenv>=0.9.0",

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,7 @@ commands =
 deps =
     pre-commit==2.15
 skip_install = true
-commands = pre-commit run --all-files --show-diff-on-failure
+commands =
+    pre-commit run pyupgrade --all-files --show-diff-on-failure
+    pre-commit run black --all-files --show-diff-on-failure
+    pre-commit run flake8 --all-files --show-diff-on-failure


### PR DESCRIPTION
pip-compile requirements in pre-commit.

In tox, select hooks to run explicitly.

Running all hooks on all files is wrong because it runs pip-compile which may modify the requirements files, thus failing CI. Selecting hooks in tox.ini seems like the right approach.

This plus a few minor fixes/updates.