### PR TITLE
Core update: configure migrations

### DIFF
--- a/bemserver_api/__init__.py
+++ b/bemserver_api/__init__.py
@@ -1,6 +1,5 @@
 """BEMServer API"""
 import flask
-import click
 
 from bemserver_core import BEMServerCore
 
@@ -15,12 +14,6 @@ from .extensions import (  # noqa
     authentication,
 )
 from .resources import register_blueprints
-
-
-@click.command()
-@flask.cli.with_appcontext
-def setup_db():
-    database.db.create_all()
 
 
 def create_app(config_override=None):
@@ -42,7 +35,5 @@ def create_app(config_override=None):
 
     bsc = BEMServerCore()
     bsc.init_auth()
-
-    app.cli.add_command(setup_db)
 
     return app

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile --output-file=requirements/install.txt setup.py
 #
+alembic==1.7.7
+    # via bemserver-core
 apispec[marshmallow]==5.1.1
     # via flask-smorest
 argon2-cffi==21.3.0
     # via bemserver-core
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-bemserver-core @ https://github.com/BEMServer/bemserver-core/archive/820693f.tar.gz
+bemserver-core @ https://github.com/BEMServer/bemserver-core/archive/efd3351.tar.gz
     # via bemserver-api (setup.py)
 cffi==1.15.0
     # via
@@ -35,8 +37,12 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.1
     # via flask
+mako==1.2.0
+    # via alembic
 markupsafe==2.1.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   mako
 marshmallow==3.15.0
     # via
     #   apispec
@@ -74,6 +80,7 @@ six==1.16.0
     # via python-dateutil
 sqlalchemy==1.4.32
     # via
+    #   alembic
     #   bemserver-core
     #   marshmallow-sqlalchemy
 webargs==8.1.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         (
             # https://github.com/jazzband/pip-tools/issues/1359
             "bemserver-core @ "
-            "https://github.com/BEMServer/bemserver-core/archive/820693f.tar.gz"
+            "https://github.com/BEMServer/bemserver-core/archive/efd3351.tar.gz"
         ),
     ],
     packages=find_packages(exclude=["tests*"]),


### PR DESCRIPTION
Also remove `setup_db`. It is kinda broken because it instantiates an app, which involves instantiating BEMServerCore, which may involve accessing the DB (not now, but thinking ahead, plugins, processors,...).

DB setup must be achieved from bemserver core (using setup_db for dev/test or alembic for prod).