### PR TITLE
Improve cleanup service APIs

### DIFF
--- a/bemserver_api/resources/st_cleanups_by_campaigns/schemas.py
+++ b/bemserver_api/resources/st_cleanups_by_campaigns/schemas.py
@@ -4,7 +4,7 @@ import marshmallow_sqlalchemy as msa
 
 from bemserver_core.scheduled_tasks import ST_CleanupByCampaign
 
-from bemserver_api import AutoSchema, Schema
+from bemserver_api import AutoSchema, Schema, SortField
 
 
 class ST_CleanupByCampaignSchema(AutoSchema):
@@ -14,5 +14,30 @@ class ST_CleanupByCampaignSchema(AutoSchema):
     id = msa.auto_field(dump_only=True)
 
 
+class ST_CleanupByCampaignPutSchema(Schema):
+    is_enabled = ma.fields.Bool()
+
+
+class ST_CleanupByCampaignFullSchema(Schema):
+    id = ma.fields.Int()
+    campaign_id = ma.fields.Int()
+    campaign_name = ma.fields.Str()
+    is_enabled = ma.fields.Bool()
+
+
 class ST_CleanupByCampaignQueryArgsSchema(Schema):
     campaign_id = ma.fields.Int()
+
+
+class ST_CleanupByCampaignFullQueryArgsSchema(Schema):
+    sort = SortField(("campaign_name",))
+    is_enabled = ma.fields.Bool()
+    campaign_id = ma.fields.Int()
+    in_campaign_name = ma.fields.Str(
+        metadata={
+            "description": (
+                "Search for items whose name contains this input value"
+                " (case insensitive)"
+            ),
+        }
+    )

--- a/bemserver_api/resources/st_cleanups_by_timeseries/routes.py
+++ b/bemserver_api/resources/st_cleanups_by_timeseries/routes.py
@@ -6,7 +6,12 @@ from bemserver_core.scheduled_tasks import ST_CleanupByTimeseries
 
 from bemserver_api import Blueprint
 
-from .schemas import ST_CleanupByTimeseriesSchema, ST_CleanupByTimeseriesQueryArgsSchema
+from .schemas import (
+    ST_CleanupByTimeseriesSchema,
+    ST_CleanupByTimeseriesQueryArgsSchema,
+    ST_CleanupByTimeseriesFullSchema,
+    ST_CleanupByTimeseriesFullQueryArgsSchema,
+)
 
 
 blp = Blueprint(
@@ -39,3 +44,13 @@ class ST_CleanupByTimeseriesByIdViews(MethodView):
         if item is None:
             abort(404)
         return item
+
+
+@blp.route("/full")
+@blp.login_required
+@blp.etag
+@blp.arguments(ST_CleanupByTimeseriesFullQueryArgsSchema, location="query")
+@blp.response(200, ST_CleanupByTimeseriesFullSchema(many=True))
+def get_full(args):
+    """List cleanup service last timestamp for all timeseries"""
+    return ST_CleanupByTimeseries.get_all(**args)

--- a/bemserver_api/resources/st_cleanups_by_timeseries/schemas.py
+++ b/bemserver_api/resources/st_cleanups_by_timeseries/schemas.py
@@ -4,7 +4,7 @@ import marshmallow_sqlalchemy as msa
 
 from bemserver_core.scheduled_tasks import ST_CleanupByTimeseries
 
-from bemserver_api import AutoSchema, Schema
+from bemserver_api import AutoSchema, Schema, SortField
 
 
 class ST_CleanupByTimeseriesSchema(AutoSchema):
@@ -14,6 +14,33 @@ class ST_CleanupByTimeseriesSchema(AutoSchema):
     id = msa.auto_field(dump_only=True)
 
 
+class ST_CleanupByTimeseriesFullSchema(Schema):
+    id = ma.fields.Int()
+    timeseries_id = ma.fields.Int()
+    timeseries_name = ma.fields.Str()
+    timeseries_unit_symbol = ma.fields.Str()
+    last_timestamp = ma.fields.AwareDateTime(allow_none=True)
+
+
 class ST_CleanupByTimeseriesQueryArgsSchema(Schema):
     campaign_id = ma.fields.Int()
     timeseries_id = ma.fields.Int()
+
+
+class ST_CleanupByTimeseriesFullQueryArgsSchema(Schema):
+    sort = SortField(
+        (
+            "timeseries_name",
+            "last_timestamp",
+        )
+    )
+    campaign_id = ma.fields.Int()
+    timeseries_id = ma.fields.Int()
+    in_timeseries_name = ma.fields.Str(
+        metadata={
+            "description": (
+                "Search for items whose name contains this input value"
+                " (case insensitive)"
+            ),
+        }
+    )

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -16,7 +16,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 async-timeout==4.0.2
     # via redis
-bemserver-core @ https://github.com/BEMServer/bemserver-core/archive/6059d72.tar.gz
+bemserver-core @ https://github.com/BEMServer/bemserver-core/archive/d8117a7.tar.gz
     # via bemserver-api (setup.py)
 billiard==3.6.4.0
     # via celery

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         (
             # https://github.com/jazzband/pip-tools/issues/1359
             "bemserver-core @ "
-            "https://github.com/BEMServer/bemserver-core/archive/6059d72.tar.gz"
+            "https://github.com/BEMServer/bemserver-core/archive/d8117a7.tar.gz"
         ),
     ],
     packages=find_packages(exclude=["tests*"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -634,7 +634,8 @@ def st_cleanups_by_timeseries(app, st_cleanups_by_campaigns, timeseries):
             timeseries_id=timeseries[0]
         )
         st_cbt_2 = scheduled_tasks.ST_CleanupByTimeseries.new(
-            timeseries_id=timeseries[1]
+            timeseries_id=timeseries[1],
+            last_timestamp=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
         )
         db.session.commit()
     return (st_cbt_1.id, st_cbt_2.id)

--- a/tests/resources/test_st_cleanups_by_timeseries.py
+++ b/tests/resources/test_st_cleanups_by_timeseries.py
@@ -10,13 +10,18 @@ ST_CLEANUPS_BY_TIMESERIES_URL = "/st_cleanups_by_timeseries/"
 
 
 class TestST_CleanupByTimeseriessApi:
+    @pytest.mark.parametrize("timeseries", (10,), indirect=True)
     def test_st_cleanups_by_timeseries_api(
-        self, app, users, campaigns, st_cleanups_by_timeseries
+        self, app, users, campaigns, timeseries, st_cleanups_by_timeseries
     ):
 
         creds = users["Chuck"]["creds"]
         campaign_1_id = campaigns[0]
+        ts_1_id = timeseries[0]
+        ts_2_id = timeseries[1]
+        ts_7_id = timeseries[6]
         st_cbt_1_id = st_cleanups_by_timeseries[0]
+        st_cbt_2_id = st_cleanups_by_timeseries[1]
 
         client = app.test_client()
 
@@ -44,16 +49,47 @@ class TestST_CleanupByTimeseriessApi:
             ret_val = ret.json
             assert ret_val["id"] == st_cbt_1_id
 
+            # GET list (full), sort by timeseries name
+            ret = client.get(
+                f"{ST_CLEANUPS_BY_TIMESERIES_URL}full",
+                query_string={"sort": "+timeseries_name"},
+            )
+            assert ret.status_code == 200
+            ret_val = ret.json
+            assert len(ret_val) == 10
+            assert ret_val[0]["id"] == st_cbt_1_id
+            assert ret_val[0]["timeseries_id"] == ts_1_id
+            assert ret_val[0]["last_timestamp"] is None
+
+            # GET list (full), sort by timeseries name and timestamps desc
+            ret = client.get(
+                f"{ST_CLEANUPS_BY_TIMESERIES_URL}full",
+                query_string={"sort": "-last_timestamp,+timeseries_name"},
+            )
+            assert ret.status_code == 200
+            ret_val = ret.json
+            assert len(ret_val) == 10
+            assert ret_val[0]["id"] == st_cbt_2_id
+            assert ret_val[0]["timeseries_id"] == ts_2_id
+            assert ret_val[0]["last_timestamp"] == "2020-01-01T00:00:00+00:00"
+            assert ret_val[1]["id"] == st_cbt_1_id
+            assert ret_val[1]["timeseries_id"] == ts_1_id
+            assert ret_val[1]["last_timestamp"] is None
+            assert ret_val[6]["id"] is None
+            assert ret_val[6]["timeseries_id"] == ts_7_id
+            assert ret_val[6]["last_timestamp"] is None
+
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")
     @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
     def test_st_cleanups_by_timeseries_as_user_api(
-        self, app, users, campaigns, st_cleanups_by_timeseries
+        self, app, users, campaigns, timeseries, st_cleanups_by_timeseries
     ):
 
         user_creds = users["Active"]["creds"]
         campaign_1_id = campaigns[0]
         campaign_2_id = campaigns[1]
+        ts_1_id = timeseries[0]
         st_cbt_1_id = st_cleanups_by_timeseries[0]
         st_cbt_2_id = st_cleanups_by_timeseries[1]
 
@@ -94,6 +130,33 @@ class TestST_CleanupByTimeseriessApi:
             ret = client.get(f"{ST_CLEANUPS_BY_TIMESERIES_URL}{st_cbt_2_id}")
             assert ret.status_code == 403
 
+            # GET list (full), sort by timeseries name
+            ret = client.get(
+                f"{ST_CLEANUPS_BY_TIMESERIES_URL}full",
+                query_string={"sort": "+timeseries_name"},
+            )
+            assert ret.status_code == 200
+            ret_val = ret.json
+            assert len(ret_val) == 1
+            assert ret_val[0]["id"] == st_cbt_1_id
+            assert ret_val[0]["timeseries_id"] == ts_1_id
+            assert ret_val[0]["last_timestamp"] is None
+
+            # GET list (full), filter by campaign id
+            ret = client.get(
+                f"{ST_CLEANUPS_BY_TIMESERIES_URL}full",
+                query_string={"campaign_id": campaign_1_id},
+            )
+            assert ret.status_code == 200
+            assert len(ret.json) == 1
+
+            # GET list (full), filter by campaign id
+            ret = client.get(
+                f"{ST_CLEANUPS_BY_TIMESERIES_URL}full",
+                query_string={"campaign_id": campaign_2_id},
+            )
+            assert ret.status_code == 403
+
     def test_st_cleanups_by_timeseries_as_anonym_api(
         self, app, st_cleanups_by_timeseries
     ):
@@ -108,4 +171,8 @@ class TestST_CleanupByTimeseriessApi:
 
         # GET by id
         ret = client.get(f"{ST_CLEANUPS_BY_TIMESERIES_URL}{st_cbt_1_id}")
+        assert ret.status_code == 401
+
+        # GET list (full)
+        ret = client.get(f"{ST_CLEANUPS_BY_TIMESERIES_URL}full")
         assert ret.status_code == 401


### PR DESCRIPTION
This updates contains "full" cleanup service status list, that includes for all campaigns (even those which have never been configured yet, they are considered as disabled) and timeseries (even those which have never been cleaned, with no last timestamp defined yet).