### PR TITLE
Use model, not table, for AutoSchema

### DIFF
--- a/bemserver_api/resources/building_properties/schemas.py
+++ b/bemserver_api/resources/building_properties/schemas.py
@@ -11,7 +11,7 @@ from ..structural_element_properties.schemas import StructuralElementPropertySch
 
 class BuildingPropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = BuildingProperty.__table__
+        model = BuildingProperty
 
     id = msa.auto_field(dump_only=True)
     structural_element_property = ma.fields.Nested(

--- a/bemserver_api/resources/building_property_data/schemas.py
+++ b/bemserver_api/resources/building_property_data/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class BuildingPropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = BuildingPropertyData.__table__
+        model = BuildingPropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/buildings/schemas.py
+++ b/bemserver_api/resources/buildings/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class BuildingSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Building.__table__
+        model = Building
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/campaign_scopes/schemas.py
+++ b/bemserver_api/resources/campaign_scopes/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class CampaignScopeSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = CampaignScope.__table__
+        model = CampaignScope
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/campaigns/schemas.py
+++ b/bemserver_api/resources/campaigns/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api.extensions.ma_fields import Timezone
 
 class CampaignSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Campaign.__table__
+        model = Campaign
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/energy_consumption_timeseries_by_buildings/schemas.py
+++ b/bemserver_api/resources/energy_consumption_timeseries_by_buildings/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class EnergyConsumptionTimeseriesByBuildingSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = EnergyConsumptionTimeseriesByBuilding.__table__
+        model = EnergyConsumptionTimeseriesByBuilding
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/energy_consumption_timeseries_by_sites/schemas.py
+++ b/bemserver_api/resources/energy_consumption_timeseries_by_sites/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class EnergyConsumptionTimeseriesBySiteSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = EnergyConsumptionTimeseriesBySite.__table__
+        model = EnergyConsumptionTimeseriesBySite
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/energy_end_uses/schemas.py
+++ b/bemserver_api/resources/energy_end_uses/schemas.py
@@ -9,6 +9,6 @@ from bemserver_api import AutoSchema
 
 class EnergyEndUseSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = EnergyEndUse.__table__
+        model = EnergyEndUse
 
     id = msa.auto_field(dump_only=True)

--- a/bemserver_api/resources/energy_sources/schemas.py
+++ b/bemserver_api/resources/energy_sources/schemas.py
@@ -9,6 +9,6 @@ from bemserver_api import AutoSchema
 
 class EnergySourceSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = EnergySource.__table__
+        model = EnergySource
 
     id = msa.auto_field(dump_only=True)

--- a/bemserver_api/resources/site_properties/schemas.py
+++ b/bemserver_api/resources/site_properties/schemas.py
@@ -11,7 +11,7 @@ from ..structural_element_properties.schemas import StructuralElementPropertySch
 
 class SitePropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = SiteProperty.__table__
+        model = SiteProperty
 
     id = msa.auto_field(dump_only=True)
     structural_element_property = ma.fields.Nested(

--- a/bemserver_api/resources/site_property_data/schemas.py
+++ b/bemserver_api/resources/site_property_data/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class SitePropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = SitePropertyData.__table__
+        model = SitePropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/sites/schemas.py
+++ b/bemserver_api/resources/sites/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class SiteSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Site.__table__
+        model = Site
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/space_properties/schemas.py
+++ b/bemserver_api/resources/space_properties/schemas.py
@@ -11,7 +11,7 @@ from ..structural_element_properties.schemas import StructuralElementPropertySch
 
 class SpacePropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = SpaceProperty.__table__
+        model = SpaceProperty
 
     id = msa.auto_field(dump_only=True)
     structural_element_property = ma.fields.Nested(

--- a/bemserver_api/resources/space_property_data/schemas.py
+++ b/bemserver_api/resources/space_property_data/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class SpacePropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = SpacePropertyData.__table__
+        model = SpacePropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/spaces/schemas.py
+++ b/bemserver_api/resources/spaces/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class SpaceSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Space.__table__
+        model = Space
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/st_cleanups_by_campaigns/schemas.py
+++ b/bemserver_api/resources/st_cleanups_by_campaigns/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class ST_CleanupByCampaignSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = ST_CleanupByCampaign.__table__
+        model = ST_CleanupByCampaign
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/st_cleanups_by_timeseries/schemas.py
+++ b/bemserver_api/resources/st_cleanups_by_timeseries/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class ST_CleanupByTimeseriesSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = ST_CleanupByTimeseries.__table__
+        model = ST_CleanupByTimeseries
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/storey_properties/schemas.py
+++ b/bemserver_api/resources/storey_properties/schemas.py
@@ -11,7 +11,7 @@ from ..structural_element_properties.schemas import StructuralElementPropertySch
 
 class StoreyPropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = StoreyProperty.__table__
+        model = StoreyProperty
 
     id = msa.auto_field(dump_only=True)
     structural_element_property = ma.fields.Nested(

--- a/bemserver_api/resources/storey_property_data/schemas.py
+++ b/bemserver_api/resources/storey_property_data/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class StoreyPropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = StoreyPropertyData.__table__
+        model = StoreyPropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/storeys/schemas.py
+++ b/bemserver_api/resources/storeys/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class StoreySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Storey.__table__
+        model = Storey
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/structural_element_properties/schemas.py
+++ b/bemserver_api/resources/structural_element_properties/schemas.py
@@ -12,7 +12,7 @@ from bemserver_api.extensions.ma_fields import EnumField
 
 class StructuralElementPropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = StructuralElementProperty.__table__
+        model = StructuralElementProperty
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/timeseries/schemas.py
+++ b/bemserver_api/resources/timeseries/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class TimeseriesSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Timeseries.__table__
+        model = Timeseries
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/timeseries_by_buildings/schemas.py
+++ b/bemserver_api/resources/timeseries_by_buildings/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesByBuildingSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesByBuilding.__table__
+        model = TimeseriesByBuilding
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/timeseries_by_sites/schemas.py
+++ b/bemserver_api/resources/timeseries_by_sites/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesBySiteSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesBySite.__table__
+        model = TimeseriesBySite
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/timeseries_by_spaces/schemas.py
+++ b/bemserver_api/resources/timeseries_by_spaces/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesBySpaceSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesBySpace.__table__
+        model = TimeseriesBySpace
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/timeseries_by_storeys/schemas.py
+++ b/bemserver_api/resources/timeseries_by_storeys/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesByStoreySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesByStorey.__table__
+        model = TimeseriesByStorey
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/timeseries_by_zones/schemas.py
+++ b/bemserver_api/resources/timeseries_by_zones/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesByZoneSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesByZone.__table__
+        model = TimeseriesByZone
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/timeseries_data_states/schemas.py
+++ b/bemserver_api/resources/timeseries_data_states/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema
 
 class TimeseriesDataStateSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesDataState.__table__
+        model = TimeseriesDataState
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/timeseries_properties/schemas.py
+++ b/bemserver_api/resources/timeseries_properties/schemas.py
@@ -12,7 +12,7 @@ from bemserver_api.extensions.ma_fields import EnumField
 
 class TimeseriesPropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesProperty.__table__
+        model = TimeseriesProperty
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/timeseries_property_data/schemas.py
+++ b/bemserver_api/resources/timeseries_property_data/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class TimeseriesPropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = TimeseriesPropertyData.__table__
+        model = TimeseriesPropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/user_groups/schemas.py
+++ b/bemserver_api/resources/user_groups/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class UserGroupSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = UserGroup.__table__
+        model = UserGroup
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))

--- a/bemserver_api/resources/user_groups_by_campaign_scopes/schemas.py
+++ b/bemserver_api/resources/user_groups_by_campaign_scopes/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class UserGroupByCampaignScopeSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = UserGroupByCampaignScope.__table__
+        model = UserGroupByCampaignScope
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/user_groups_by_campaigns/schemas.py
+++ b/bemserver_api/resources/user_groups_by_campaigns/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class UserGroupByCampaignSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = UserGroupByCampaign.__table__
+        model = UserGroupByCampaign
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/users/schemas.py
+++ b/bemserver_api/resources/users/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class UserSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = User.__table__
+        model = User
         exclude = ("_is_active", "_is_admin")
 
     id = msa.auto_field(dump_only=True)

--- a/bemserver_api/resources/users_by_user_groups/schemas.py
+++ b/bemserver_api/resources/users_by_user_groups/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema
 
 class UserByUserGroupSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = UserByUserGroup.__table__
+        model = UserByUserGroup
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/zone_properties/schemas.py
+++ b/bemserver_api/resources/zone_properties/schemas.py
@@ -11,7 +11,7 @@ from ..structural_element_properties.schemas import StructuralElementPropertySch
 
 class ZonePropertySchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = ZoneProperty.__table__
+        model = ZoneProperty
 
     id = msa.auto_field(dump_only=True)
     structural_element_property = ma.fields.Nested(

--- a/bemserver_api/resources/zone_property_data/schemas.py
+++ b/bemserver_api/resources/zone_property_data/schemas.py
@@ -10,7 +10,7 @@ from bemserver_api import AutoSchema, Schema
 
 class ZonePropertyDataSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = ZonePropertyData.__table__
+        model = ZonePropertyData
 
     id = msa.auto_field(dump_only=True)
 

--- a/bemserver_api/resources/zones/schemas.py
+++ b/bemserver_api/resources/zones/schemas.py
@@ -9,7 +9,7 @@ from bemserver_api import AutoSchema, Schema, SortField
 
 class ZoneSchema(AutoSchema):
     class Meta(AutoSchema.Meta):
-        table = Zone.__table__
+        model = Zone
 
     id = msa.auto_field(dump_only=True)
     name = msa.auto_field(validate=ma.validate.Length(1, 80))


### PR DESCRIPTION
For some reason, we've been using table all along but apparently model is the recommended way and when using table, schemas are generated with columns names, which is bad if the column name doesn't match the field key in the schema.